### PR TITLE
Only include Swift files in the source_files

### DIFF
--- a/LithoUXComponents.podspec
+++ b/LithoUXComponents.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'LithoUXComponents'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'LithoUXComponents contains everything you need to create a simple app.'
 
   s.description      = <<-DESC

--- a/LithoUXComponents.podspec
+++ b/LithoUXComponents.podspec
@@ -24,7 +24,7 @@ There's a bunch of really cool stuff in this pod, all targeted at letting you bu
 
   s.ios.deployment_target = '10.0'
 
-  s.source_files = 'LithoUXComponents/Classes/**/*'
+  s.source_files = 'LithoUXComponents/Classes/**/*.swift'
   
   s.resources = 'LithoUXComponents/**/*.xib'
   # s.resource_bundles = {


### PR DESCRIPTION
If you include xib files in both the `resources` and the `source_files`, the downstream project won't compile once this library is integrating. Locking down `source_files` to just Swift files means that xibs will only be included once. For more info, see this comment [here](https://github.com/CocoaPods/CocoaPods/issues/7079#issuecomment-346053285): 

> Yep… same case here. It’s fixed when you add resources (xibs, assets, etc.) to resources and not to the source files. Maybe the linting should warn for this if you are trying to add xib files to the source files?